### PR TITLE
chore: dependency maintenance 2026-05-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cf-kaizen follows a modular architecture with several components working togethe
 ### Backend
 
 - **Java 25**: Base programming language (LTS, Liberica distribution)
-- **Spring Boot 4.0.3+**: Primary application framework
+- **Spring Boot 4.0.6+**: Primary application framework
 - **Spring WebFlux**: Reactive web framework
 - **Spring AI**: Framework for AI model integration
 - **Model Context Protocol (MCP)**: Protocol for AI model interaction with external tools

--- a/clients/butler/src/main/frontend/package.json
+++ b/clients/butler/src/main/frontend/package.json
@@ -29,10 +29,10 @@
     "devDependencies": {
       "@types/react": "^18.2.43",
       "@types/react-dom": "^18.2.17",
-      "@vitejs/plugin-react": "^4.2.1",
+      "@vitejs/plugin-react": "^4.7.0",
       "autoprefixer": "^10.4.16",
       "postcss": "^8.4.32",
       "tailwindcss": "^3.4.0",
-      "vite": "^5.0.8"
+      "vite": "^6.4.2"
     }
   }

--- a/clients/butler/src/main/java/org/cftoolsuite/cfapp/service/ai/McpAsyncClientManager.java
+++ b/clients/butler/src/main/java/org/cftoolsuite/cfapp/service/ai/McpAsyncClientManager.java
@@ -3,7 +3,7 @@ package org.cftoolsuite.cfapp.service.ai;
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
-import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
@@ -45,7 +45,7 @@ public class McpAsyncClientManager {
 		for (Map.Entry<String, McpSseClientProperties.SseParameters> serverParameters : mcpSseClientProperties
 				.getConnections().entrySet()) {
 			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(serverParameters.getValue().url());
-			var transport = new WebFluxSseClientTransport(webClientBuilder, McpJsonMapper.getDefault());
+			var transport = new WebFluxSseClientTransport(webClientBuilder, McpJsonDefaults.getMapper());
 			namedTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}
 

--- a/clients/hoover/src/main/frontend/package.json
+++ b/clients/hoover/src/main/frontend/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "vite": "^5.0.8"
+    "vite": "^6.4.2"
   }
 }

--- a/clients/hoover/src/main/java/org/cftoolsuite/cfapp/service/ai/McpAsyncClientManager.java
+++ b/clients/hoover/src/main/java/org/cftoolsuite/cfapp/service/ai/McpAsyncClientManager.java
@@ -3,7 +3,7 @@ package org.cftoolsuite.cfapp.service.ai;
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
-import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
@@ -45,7 +45,7 @@ public class McpAsyncClientManager {
 		for (Map.Entry<String, McpSseClientProperties.SseParameters> serverParameters : mcpSseClientProperties
 				.getConnections().entrySet()) {
 			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(serverParameters.getValue().url());
-			var transport = new WebFluxSseClientTransport(webClientBuilder, McpJsonMapper.getDefault());
+			var transport = new WebFluxSseClientTransport(webClientBuilder, McpJsonDefaults.getMapper());
 			namedTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.6</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -73,17 +73,17 @@
 	<properties>
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-ai.version>1.1.2</spring-ai.version>
-		<jackson-databind-nullable.version>0.2.8</jackson-databind-nullable.version>
+		<spring-ai.version>1.1.6</spring-ai.version>
+		<jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
 		<spring-doc.version>3.0.1</spring-doc.version>
-		<cfenv.version>3.5.0</cfenv.version>
-		<commons-io.version>2.21.0</commons-io.version>
+		<cfenv.version>4.0.0</cfenv.version>
+		<commons-io.version>2.22.0</commons-io.version>
 		<json-io.version>4.80.0</json-io.version>
 		<node.version>v23.4.0</node.version>
 		<npm.version>10.9.2</npm.version>
-		<spring-boot-hc5.version>2.0.0</spring-boot-hc5.version>
+		<spring-boot-hc5.version>2.0.1</spring-boot-hc5.version>
 		<spring-cloud-bindings.version>2.0.4</spring-cloud-bindings.version>
-		<assertj.version>3.27.6</assertj.version>
+		<assertj.version>3.27.7</assertj.version>
 	</properties>
 
 	<build>
@@ -215,14 +215,14 @@
 			<dependency>
 				<groupId>io.micrometer</groupId>
 				<artifactId>micrometer-bom</artifactId>
-				<version>1.16.1</version>
+				<version>1.16.5</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>io.opentelemetry</groupId>
 				<artifactId>opentelemetry-bom</artifactId>
-				<version>1.57.0</version>
+				<version>1.62.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -296,7 +296,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.9.0</version>
+						<version>0.10.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Dependency Maintenance

Consolidates 10 open Dependabot PRs, addresses 2 Dependabot security alerts, and fixes one breaking API change.

### Version Changes

| Artifact | From | To |
|---|---|---|
| spring-boot-starter-parent | 4.0.3 | 4.0.6 |
| spring-ai-bom | 1.1.2 | 1.1.6 |
| cfenv.version | 3.5.0 | 4.0.0 |
| commons-io | 2.21.0 | 2.22.0 |
| spring-boot-hc5.version | 2.0.0 | 2.0.1 |
| assertj.version | 3.27.6 | 3.27.7 |
| jackson-databind-nullable.version | 0.2.8 | 0.2.10 |
| micrometer-bom | 1.16.1 | 1.16.5 |
| opentelemetry-bom | 1.57.0 | 1.62.0 |
| central-publishing-maven-plugin | 0.9.0 | 0.10.0 |
| vite (hoover + butler frontends) | ^5.0.8 | ^6.4.2 |
| @vitejs/plugin-react | ^4.2.1 | ^4.7.0 |

### Security Fixes

- **Vite path traversal** (Dependabot alerts #1 and #2, medium severity) — upgraded from `^5.0.8` to `^6.4.2` which contains the fix for path traversal in optimized deps `.map` handling. Also bumped `@vitejs/plugin-react` to `^4.7.0` (supports vite `^4 || ^5 || ^6 || ^7`).

### Code Fixes

- **`McpAsyncClientManager`** (both butler and hoover clients) — MCP SDK 0.18.2 removed `McpJsonMapper.getDefault()` as a static interface method. Replaced with `McpJsonDefaults.getMapper()` from the new `McpJsonDefaults` utility class.

### GitHub Actions

No updates needed — `actions/checkout@v6`, `actions/setup-java@v5`, and `actions/cache@v5` were already at current versions.

### Quality Gates

| Gate | Result |
|---|---|
| `spotless:apply` | PASSED |
| `compile` | PASSED |
| `test` | PASSED |

### Closed Dependabot PRs

PRs #111–#120 closed with consolidation comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)