### PR TITLE
fix: remediate Snyk CVEs — Netty, commons-fileupload, BouncyCastle, prismjs, config-server upgrade

### DIFF
--- a/clients/butler/src/main/frontend/package.json
+++ b/clients/butler/src/main/frontend/package.json
@@ -18,7 +18,7 @@
       "react-dom": "^18.2.0",
       "react-markdown": "^9.0.3",
       "react-swipeable": "^7.0.1",
-      "react-syntax-highlighter": "^15.6.1",
+      "react-syntax-highlighter": "^16.0.0",
       "rehype-raw": "^7.0.0",
       "rehype-format": "^5.0.1",
       "remark-gfm": "^4.0.0",

--- a/clients/hoover/src/main/frontend/package.json
+++ b/clients/hoover/src/main/frontend/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.3",
     "react-swipeable": "^7.0.1",
-    "react-syntax-highlighter": "^15.6.1",
+    "react-syntax-highlighter": "^16.0.0",
     "rehype-raw": "^7.0.0",
     "rehype-format": "^5.0.1",
     "remark-gfm": "^4.0.0",

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
 		<spring-boot-hc5.version>2.0.1</spring-boot-hc5.version>
 		<spring-cloud-bindings.version>2.0.4</spring-cloud-bindings.version>
 		<assertj.version>3.27.7</assertj.version>
+		<!-- CVE remediation: override Spring Boot-managed Netty to fix HTTP smuggling/compression/transport CVEs -->
+		<netty.version>4.2.13.Final</netty.version>
 	</properties>
 
 	<build>
@@ -225,6 +227,18 @@
 				<version>1.62.0</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!-- CVE remediation: commons-fileupload 1.6.0 fixes SNYK-JAVA-COMMONSFILEUPLOAD-10363252 -->
+			<dependency>
+				<groupId>commons-fileupload</groupId>
+				<artifactId>commons-fileupload</artifactId>
+				<version>1.6.0</version>
+			</dependency>
+			<!-- CVE remediation: bcprov-jdk18on 1.84 fixes SNYK-JAVA-ORGBOUNCYCASTLE-16074612/16075254/16075266 -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/support/config-server/pom.xml
+++ b/support/config-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>4.0.6</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -28,11 +28,11 @@
     </licenses>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <!-- CVE remediation: force Tomcat 11.0.22 via Spring Boot BOM property -->
+        <tomcat.version>11.0.22</tomcat.version>
     </properties>
 
     <developers>
@@ -304,16 +304,28 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2025.0.0</version>
+                <version>2025.1.1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-services-dependencies</artifactId>
-                <version>4.3.0</version>
+                <version>4.4.0</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- CVE remediation: spring-cloud-commons pulls bcprov-jdk18on@1.81; force 1.84 (no BOM property available) -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <!-- CVE remediation: spring-cloud-config-server 5.0.3 fixes directory traversal CVEs (BOM property non-overridable) -->
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-config-server</artifactId>
+                <version>5.0.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/support/config-server/src/main/resources/application.yml
+++ b/support/config-server/src/main/resources/application.yml
@@ -10,7 +10,7 @@
 server:
   compression:
     enabled: true
-  undertow:
+  tomcat:
     accesslog:
       enabled: true
 


### PR DESCRIPTION
## Summary

Remediates all actionable Snyk security findings across the repository.

| CVE ID | Severity | Affected Package (was → fixed) | Fix Method |
|---|---|---|---|
| SNYK-JAVA-IONETTY-16425695 | Medium | netty-codec-http 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438737 | High | netty-codec-http 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438923 | High | netty-codec-http 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438926 | Medium | netty-codec-http 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438934 | High | netty-codec-http 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438323 | High | netty-codec-compression 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438931 | High | netty-codec-compression 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438929 | High | netty-codec-http2 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438935 | Medium | netty-handler-proxy 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438936 | High | netty-transport-classes-epoll 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438938 | High | netty-codec-dns 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-IONETTY-16438978 | High | netty-codec-http3 4.2.12 → 4.2.13.Final | `netty.version` property (root pom) |
| SNYK-JAVA-COMMONSFILEUPLOAD-10363252 | High | commons-fileupload 1.5 → 1.6.0 | Explicit `dependencyManagement` (root pom) |
| SNYK-JAVA-ORGBOUNCYCASTLE-16074612 | High | bcprov-jdk18on 1.81 → 1.84 | Explicit `dependencyManagement` (root pom + config-server) |
| SNYK-JAVA-ORGBOUNCYCASTLE-16075254 | Medium | bcprov-jdk18on 1.81 → 1.84 | Explicit `dependencyManagement` (root pom + config-server) |
| SNYK-JAVA-ORGBOUNCYCASTLE-16075266 | High | bcprov-jdk18on 1.81 → 1.84 | Explicit `dependencyManagement` (root pom + config-server) |
| SNYK-JS-PRISMJS-9055448 | Low | prismjs 1.27.0 → fixed via react-syntax-highlighter@16.0.0 | `package.json` bump (butler + hoover frontends) |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-* (6 CVEs) | Critical/High/Medium | tomcat-embed-core 10.1.x / 11.0.21 → 11.0.22 | `tomcat.version` property (config-server) |
| SNYK-JAVA-ORGSPRINGFRAMEWORKCLOUD-16439043/108/15762281 | High | spring-cloud-config-server 4.3.0 → 5.0.3 | Spring Boot 4 upgrade + explicit `dependencyManagement` (config-server) |
| SNYK-JAVA-ORGSPRINGFRAMEWORKCLOUD-16439020/25 | Medium | spring-cloud-config-server 4.3.0 → 5.0.3 | Spring Boot 4 upgrade + explicit `dependencyManagement` (config-server) |

## Config-server: orphan module aligned to Spring Boot 4

`support/config-server` was previously a standalone orphan using Spring Boot 3.5.3 and Spring Cloud 2025.0.0. It has been upgraded to match the rest of the monorepo:

- `spring-boot-starter-parent` 3.5.3 → **4.0.6**
- `spring-cloud-dependencies` 2025.0.0 → **2025.1.1**
- `spring-cloud-services-dependencies` 4.3.0 → **4.4.0**
- `java.version` 21 → **25**
- `application.yml`: `server.undertow.accesslog` → `server.tomcat.accesslog` (Tomcat is the active embedded server)

## Known remaining findings (no upstream patch available)

- `SNYK-JAVA-IOMODELCONTEXTPROTOCOLSDK-15857186` (Medium) — `mcp-core@0.18.2` via `spring-ai@1.1.6`. Fix requires upgrading Spring AI to a version that bundles mcp-core 1.x; forced override would break spring-ai's compiled API contracts.
- Snyk false positives on `butler/pom.xml` and `hoover/pom.xml`: snyk resolves these standalone modules without the local SNAPSHOT parent, producing old Spring 2.x dependency trees. Actual compiled artifacts use Spring Boot 4.0.6 (verified via `mvn dependency:tree`).

## Test plan

- [x] `npm audit` → 0 vulnerabilities in both frontends
- [x] `./mvnw compile -pl butler,hoover,clients -am` → succeeds
- [x] `./mvnw compile` in `support/config-server` → succeeds
- [x] `./mvnw dependency:tree -pl butler | grep netty` → all netty artifacts at 4.2.13.Final
- [x] `snyk test --all-projects` → root pom and config-server clean; npm targets clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)